### PR TITLE
Fixed `expr: syntax error` from jython

### DIFF
--- a/jython/bin/jython
+++ b/jython/bin/jython
@@ -28,8 +28,8 @@ PRG=$0
 while [ -h "$PRG" ] ; do
   ls=`ls -ld "$PRG"`
   link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '.*/.*' > /dev/null; then
-    if expr "$link" : '/' > /dev/null; then
+  if expr "$link" : '.*\/.*' > /dev/null; then
+    if expr "$link" : '\/' > /dev/null; then
       PRG="$link"
     else
       PRG="`dirname ${PRG}`/${link}"


### PR DESCRIPTION
See: http://bugs.jython.org/issue1978
